### PR TITLE
Updated Orleans dependencies to 2.0.0 (non-beta)

### DIFF
--- a/src/Orleans.Providers.RabbitMQ/Orleans.Providers.RabbitMQ.csproj
+++ b/src/Orleans.Providers.RabbitMQ/Orleans.Providers.RabbitMQ.csproj
@@ -23,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0-beta3" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-beta3" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Orleans v2 is out of beta.